### PR TITLE
Fix NodeNext import paths

### DIFF
--- a/src/context/createLocator.ts
+++ b/src/context/createLocator.ts
@@ -1,7 +1,7 @@
-import { parseGeo } from '../parse/parseGeo';
-import type { DataLoader } from '../data/loader';
-import type { VisitorContext, Config, Airport } from '../interfaces';
-import { lookupAirportsByCoords, hasRegularService } from '../queries/airports';
+import { parseGeo } from '../parse/parseGeo.js';
+import type { DataLoader } from '../data/loader.js';
+import type { VisitorContext, Config, Airport } from '../interfaces.js';
+import { lookupAirportsByCoords, hasRegularService } from '../queries/airports.js';
 
 export interface IncludeOptions {
   airports?: boolean | { count?: number; regularServiceOnly?: boolean };

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,13 +1,13 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { FSLoader } from '../data/fs-loader';
-import { MemoryCacheLoader } from '../data/memory-cache';
-import { createLocator } from './createLocator';
-import * as C from '../queries/countries';
-import * as R from '../queries/regions';
-import * as Cur from '../queries/currencies';
-import * as L from '../queries/languages';
-import * as A from '../queries/airports';
+import { FSLoader } from '../data/fs-loader.js';
+import { MemoryCacheLoader } from '../data/memory-cache.js';
+import { createLocator } from './createLocator.js';
+import * as C from '../queries/countries.js';
+import * as R from '../queries/regions.js';
+import * as Cur from '../queries/currencies.js';
+import * as L from '../queries/languages.js';
+import * as A from '../queries/airports.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const loader = new MemoryCacheLoader(new FSLoader(path.join(__dirname, '../generated')));

--- a/src/data/fs-loader.ts
+++ b/src/data/fs-loader.ts
@@ -1,9 +1,9 @@
 import fs from 'fs/promises';
 import path from 'path';
 import type RBush from 'rbush';
-import type { DataLoader } from './loader';
-import type { Country, Region, CurrencyDetails, LanguageDetails, Airport, AirportIndexItem } from '../interfaces';
-import { DataLoadError } from './errors';
+import type { DataLoader } from './loader.js';
+import type { Country, Region, CurrencyDetails, LanguageDetails, Airport, AirportIndexItem } from '../interfaces.js';
+import { DataLoadError } from './errors.js';
 
 export class FSLoader implements DataLoader {
   constructor(private baseDir: string) {}

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -1,4 +1,4 @@
-import type { Country, Region, CurrencyDetails, LanguageDetails, Airport, AirportIndexItem } from '../interfaces';
+import type { Country, Region, CurrencyDetails, LanguageDetails, Airport, AirportIndexItem } from '../interfaces.js';
 import type RBush from 'rbush';
 
 export interface DataLoader {

--- a/src/data/memory-cache.ts
+++ b/src/data/memory-cache.ts
@@ -1,5 +1,5 @@
-import type { DataLoader } from './loader';
-import type { Country, Region, CurrencyDetails, LanguageDetails, Airport, AirportIndexItem } from '../interfaces';
+import type { DataLoader } from './loader.js';
+import type { Country, Region, CurrencyDetails, LanguageDetails, Airport, AirportIndexItem } from '../interfaces.js';
 import type RBush from 'rbush';
 
 export class MemoryCacheLoader implements DataLoader {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export {
   lookupAirportsByCoords,
   lookupAirportByIcao,
   lookupAirportByIata,
-} from './context';
+} from './context/index.js';
 
 export type {
   VisitorContext,
@@ -18,4 +18,4 @@ export type {
   CurrencyDetails,
   LanguageDetails,
   GeoInfo,
-} from './interfaces';
+} from './interfaces.js';

--- a/src/parse/parseGeo.ts
+++ b/src/parse/parseGeo.ts
@@ -1,4 +1,4 @@
-import { GeoInfo } from '../interfaces';
+import { GeoInfo } from '../interfaces.js';
 
 export function parseGeo(headers: Headers | Record<string, string | string[] | undefined>): GeoInfo {
   const getHeader = (key: string): string | null => {

--- a/src/queries/airports.ts
+++ b/src/queries/airports.ts
@@ -1,7 +1,7 @@
 import knn from 'rbush-knn';
-import type { DataLoader } from '../data/loader';
-import type { Airport } from '../interfaces';
-import type { Predicate } from '../utils/predicates';
+import type { DataLoader } from '../data/loader.js';
+import type { Airport, AirportIndexItem } from '../interfaces.js';
+import type { Predicate } from '../utils/predicates.js';
 
 export interface AirportOptions {
   count?: number;
@@ -18,7 +18,7 @@ export async function lookupAirportsByCoords(
 ): Promise<Airport[]> {
   const { airports, airportIndex } = await loader.loadAirports();
   const searchCount = opts.filter ? Math.max(opts.count ?? 10, 500) : (opts.count ?? 10);
-  const nearest = knn(airportIndex as any, lon, lat, searchCount);
+  const nearest = knn(airportIndex as any, lon, lat, searchCount) as unknown as AirportIndexItem[];
 
   const filter = opts.filter ?? (() => true);
   const out: Airport[] = [];

--- a/src/queries/countries.ts
+++ b/src/queries/countries.ts
@@ -1,5 +1,5 @@
-import type { DataLoader } from '../data/loader';
-import type { Country } from '../interfaces';
+import type { DataLoader } from '../data/loader.js';
+import type { Country } from '../interfaces.js';
 
 export async function lookupCountry(loader: DataLoader, code: string): Promise<Country | null> {
   const countries = await loader.loadCountries();

--- a/src/queries/currencies.ts
+++ b/src/queries/currencies.ts
@@ -1,5 +1,5 @@
-import type { DataLoader } from '../data/loader';
-import type { CurrencyDetails } from '../interfaces';
+import type { DataLoader } from '../data/loader.js';
+import type { CurrencyDetails } from '../interfaces.js';
 
 export async function lookupCurrency(loader: DataLoader, code: string): Promise<CurrencyDetails | null> {
   const currencies = await loader.loadCurrencies();

--- a/src/queries/languages.ts
+++ b/src/queries/languages.ts
@@ -1,5 +1,5 @@
-import type { DataLoader } from '../data/loader';
-import type { LanguageDetails, Country } from '../interfaces';
+import type { DataLoader } from '../data/loader.js';
+import type { LanguageDetails, Country } from '../interfaces.js';
 
 export async function lookupLanguage(loader: DataLoader, code: string): Promise<LanguageDetails | null> {
   const languages = await loader.loadLanguages();

--- a/src/queries/regions.ts
+++ b/src/queries/regions.ts
@@ -1,5 +1,5 @@
-import type { DataLoader } from '../data/loader';
-import type { Region } from '../interfaces';
+import type { DataLoader } from '../data/loader.js';
+import type { Region } from '../interfaces.js';
 
 export async function lookupRegion(loader: DataLoader, code: string): Promise<Region | null> {
   const regions = await loader.loadRegions();


### PR DESCRIPTION
## Summary
- add `.js` extension to relative imports for NodeNext compatibility
- type airport index items to fix TypeScript error

## Testing
- `npm test`
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_68834b498ca0832cbe741a6acdad8143